### PR TITLE
Add 53x5 GTLS code and image capture script

### DIFF
--- a/driver_53x5.py
+++ b/driver_53x5.py
@@ -4,7 +4,7 @@ import os
 from wrapless import Device, decode_u32
 from protocol import USBProtocol
 
-from mbedtls import hashlib
+from Crypto.Hash import SHA256
 
 VALID_FIRMWARE: str = "GF5288_HTSEC_APP_10020"
 
@@ -21,7 +21,7 @@ PSK_WHITE_BOX: bytes = bytes.fromhex(
 
 def is_valid_psk(device: Device) -> bool:
     psk_hash = device.read_psk_hash()
-    return psk_hash == hashlib.sha256(PSK).digest()
+    return psk_hash == SHA256.SHA256Hash(PSK).digest()
 
 
 def write_psk(device: Device):

--- a/driver_53x5.py
+++ b/driver_53x5.py
@@ -3,6 +3,7 @@ import os
 
 from wrapless import Device, decode_u32
 from protocol import USBProtocol
+from tool import decode_image, write_pgm
 
 from Crypto.Hash import SHA256
 
@@ -17,6 +18,9 @@ PSK_WHITE_BOX: bytes = bytes.fromhex(
     "6fd66b1d97cf80f1345f76c84f03ff30bb51bf308f2a9875c41e6592cd2a2f9e"
     "60809b17b5316037b69bb2fa5d4c8ac31edb3394046ec06bbdacc57da6a756c5"
 )
+
+SENSOR_WIDTH = 108
+SENSOR_HEIGHT = 88
 
 
 def is_valid_psk(device: Device) -> bool:
@@ -60,3 +64,9 @@ def main(product: int) -> None:
     print("Establishing GTLS connection")
     device.establish_gtls_connection(PSK)
     print("Connection successfully established")
+
+    print("Getting image")
+    data = device.get_sensor_data(b"\x01\x06\xbe\x00", 1)
+
+    print("Decoding and saving image")
+    write_pgm(decode_image(data), SENSOR_HEIGHT, SENSOR_WIDTH, "image.pgm")

--- a/driver_53x5.py
+++ b/driver_53x5.py
@@ -1,7 +1,7 @@
 import logging
 import os
 
-from wrapless import Device
+from wrapless import Device, decode_u32
 from protocol import USBProtocol
 
 from mbedtls import hashlib
@@ -43,6 +43,13 @@ def main(product: int) -> None:
     print(f"Firmware version: {firmware_version}")
     if firmware_version != VALID_FIRMWARE:
         raise Exception("Chip does not have a valid firmware")
+
+    reg_data = device.read_sensor_register(0, 4, 0.2)
+    chip_id = decode_u32(reg_data)
+    print(f"Chip ID: {hex(chip_id)}")
+
+    otp = device.read_otp(0.2)
+    print(f"OTP: {otp.hex(' ')}")
 
     print("Checking PSK hash")
     if not is_valid_psk(device):

--- a/driver_53x5.py
+++ b/driver_53x5.py
@@ -49,3 +49,7 @@ def main(product: int) -> None:
         print("Updating PSK")
         write_psk(device)
     print("All-zero PSK set up")
+
+    print("Establishing GTLS connection")
+    device.establish_gtls_connection(PSK)
+    print("Connection successfully established")

--- a/wireshark/wrapless_goodix_message.lua
+++ b/wireshark/wrapless_goodix_message.lua
@@ -44,6 +44,10 @@ gtls_type = ProtoField.uint32("goodix.gtls.type", "TLS Handshake message type", 
 gtls_length = ProtoField.uint32("goodix.gtls.length", "TLS Handshake message length", base.UNIT_STRING, {" bytes"})
 gtls_content = ProtoField.bytes("goodix.gtls.content", "TLS Handshake content", base.SPACE)
 
+image_type = ProtoField.uint32("goodix.image.type", "Image message type", base.HEX)
+image_length = ProtoField.uint32("goodix.image.length", "Image message length", base.UNIT_STRING, {" bytes"})
+image_content = ProtoField.bytes("goodix.image.content", "Image message content", base.SPACE)
+
 firmware_offset = ProtoField.uint32("goodix.firmware.offset", "Firmware Offset")
 firmware_length = ProtoField.uint32("goodix.firmware.length", "Firmware Lenght")
 firmware_checksum = ProtoField.uint32("goodix.firmware.checksum", "Firmware Checksum")
@@ -63,7 +67,7 @@ protocol.fields = {pack_flags, cmd0_field, cmd1_field, contd_field, length_field
                    mcu_state_spi, mcu_state_locked, reset_sensor, reset_mcu, reset_sensor_copy, reset_number,
                    register_multiple, register_address, read_length, powerdown_scan_frequency, config_sensor_chip, mode,
                    base_type, psk_msg_type, psk_msg_length, psk_msg_content, gtls_type, gtls_length, gtls_content,
-                   firmware_offset, firmware_length, firmware_checksum}
+                   image_type, image_length, image_content, firmware_offset, firmware_length, firmware_checksum}
 
 function extract_cmd0_cmd1(cmd)
     return bit.rshift(cmd, 4), bit.rshift(cmd % 16, 1)
@@ -99,6 +103,9 @@ commands = {
                 tree:add_le(base_type, buf(1, 1))
             end,
             dissect_reply = function(tree, buf)
+                tree:add_le(image_type, buf(0, 4))
+                tree:add_le(image_length, buf(4, 4))
+                tree:add(image_content, buf(8))
             end
         }
     },

--- a/wrapless.py
+++ b/wrapless.py
@@ -306,6 +306,19 @@ class Device:
 
         return reply.payload
 
+    def get_sensor_data(self, payload: bytes, timeout: float) -> bytes:
+        assert len(payload) == 4
+
+        self._send_message_to_device(Message(0x2, 0, payload), True, 0.5)
+
+        message = self._recv_message_from_device(timeout)
+        if message.category != 0x2 or message.command != 0:
+            raise Exception("Not a sensor data message")
+
+        if self.gtls_context is None or not self.gtls_context.is_connected():
+            raise Exception("Invalid GTLS connection state")
+        return self.gtls_context.decrypt_sensor_data(message.payload)
+
 
 class GTLSContext:
     def __init__(self, psk: bytes, device: Device):

--- a/wrapless.py
+++ b/wrapless.py
@@ -101,7 +101,7 @@ class Device:
 
         msg_checksum = data[-1]
         data = data[:-1]
-        if msg_checksum != b"\x88":
+        if msg_checksum != 0x88:
             checksum = 0xAA - sum(data) & 0xFF
             if msg_checksum != checksum:
                 raise Exception(

--- a/wrapless.py
+++ b/wrapless.py
@@ -65,7 +65,7 @@ class Device:
 
             raise error
 
-    def _recv_next_chunk(self, timeout: float) -> None:
+    def _recv_next_chunk(self, timeout: float) -> bytes:
         for _ in range(10):
             chunk = self.protocol.read(USB_CHUNK_SIZE, timeout=timeout)
             if chunk:
@@ -75,7 +75,7 @@ class Device:
     def _recv_message_from_device(
         self,
         timeout: float,
-    ) -> None:
+    ) -> Message:
         data = self._recv_next_chunk(timeout)
         logging.debug(f"Received chunk from device: {data.hex(' ')}")
 


### PR DESCRIPTION
This PR adds the code to handle the GTLS encrypted connection. This allowed me to receive and decrypt an image from the 5395 sensor, but it should work on all 53x5 sensors with the same size. In addition, it adds the code to read the chip ID and the OTP.