### PR TITLE
5395: Add flasher to fix broken sensors

### DIFF
--- a/flash_5395.py
+++ b/flash_5395.py
@@ -1,0 +1,4 @@
+import flasher_53x5
+
+# A 5395 sensor in IAP mode reports 5740 as USB PID
+flasher_53x5.main(0x5740, "GF5288_HTSEC_APP_10020.bin")

--- a/flasher_53x5.py
+++ b/flasher_53x5.py
@@ -1,0 +1,29 @@
+import logging
+import os
+
+import protocol
+import wrapless
+
+
+def main(product: int, target_firmware_name: str):
+    if "DEBUG" in os.environ:
+        logging.basicConfig(level=logging.DEBUG)
+
+    device = wrapless.Device(product, protocol.USBProtocol)
+    device.ping()
+
+    firmware_version = device.read_firmware_version()
+    print(f"Firmware version: {firmware_version}")
+
+    _, chip_vendor, kind, _ = firmware_version.split("_")
+    if kind != "IAP":
+        raise Exception("Chip already has firmware")
+
+    target_chip_vendor = target_firmware_name.split("_")[1]
+    if chip_vendor != target_chip_vendor:
+        raise Exception("Chip vendor does not match")
+
+    with open(f"firmware/53x5/{target_firmware_name}.bin", "rb") as firmware_file:
+        firmware = firmware_file.read()
+
+    device.update_firmware(firmware)


### PR DESCRIPTION
This code is supposed to be used with 5395 sensors that are now reporting as 5740 with a "IAP" firmware version. It requires checking out [this MR][MR] to the firmware submodule.

[MR]: https://gitlab.freedesktop.org/mpi3d/goodix-firmware/-/merge_requests/1