### PR TITLE
53x5: Add dumper script

### DIFF
--- a/dump_5395.py
+++ b/dump_5395.py
@@ -1,0 +1,3 @@
+import dumper_53x5
+
+dumper_53x5.main(0x5395)

--- a/dumper_53x5.py
+++ b/dumper_53x5.py
@@ -1,0 +1,93 @@
+import logging
+import os
+
+import protocol
+import wrapless
+
+IAP_START = 0x0
+IAP_END = 0x3000
+IAP_FILE = "iap_firmware.bin"
+APP_FILE = "app_firmware.bin"
+
+PAGE_SIZE = 0x200
+NUM_PAGES = 256
+
+
+def dump_iap_firmware(device):
+    print(f"Dumping IAP firmware from {hex(IAP_START)} to {hex(IAP_END)}")
+    dump = b""
+    for page_start in range(IAP_START, IAP_END, 0x400):
+        dump += device.read_firmware(page_start, 0x400)
+
+    print(f"Writing dumped IAP firmware to {IAP_FILE}")
+    with open(IAP_FILE, "wb") as dump_file:
+        dump_file.write(dump)
+
+
+def extract_firmware_info(last_flash_page):
+    firmware_length = int.from_bytes(
+        last_flash_page[PAGE_SIZE - 8 : PAGE_SIZE - 4], byteorder="little"
+    )
+    firmware_crc32 = int.from_bytes(
+        last_flash_page[PAGE_SIZE - 4 : PAGE_SIZE], byteorder="little"
+    )
+
+    firmware_length_not = int.from_bytes(
+        last_flash_page[PAGE_SIZE - 0x10 : PAGE_SIZE - 0xC], byteorder="little"
+    )
+    firmware_crc32_not = int.from_bytes(
+        last_flash_page[PAGE_SIZE - 0xC : PAGE_SIZE - 0x8], byteorder="little"
+    )
+
+    assert firmware_length == firmware_length_not ^ 0xFFFFFFFF
+    assert firmware_crc32 == firmware_crc32_not ^ 0xFFFFFFFF
+
+    return (firmware_length, firmware_crc32)
+
+
+def dump_app_firmware(device, firmware_length):
+    print(
+        f"Dumping APP firmware from {hex(IAP_END)} to {hex(IAP_END + firmware_length)}"
+    )
+    dump = b""
+    for page_start in range(IAP_END, IAP_END + firmware_length, 0x400):
+        dump += device.read_firmware(page_start, 0x400)
+
+    dump = dump[:firmware_length]
+
+    print(f"Writing dumped APP firmware to {APP_FILE}")
+    with open(APP_FILE, "wb") as dump_file:
+        dump_file.write(dump)
+
+
+def dump_option_byte(device):
+    print(f"Dumping option byte")
+    option_byte = device.read_option_byte()
+    print(option_byte)
+
+
+def main(product: int):
+    if "DEBUG" in os.environ:
+        logging.basicConfig(level=logging.DEBUG)
+
+    device = wrapless.Device(product, protocol.USBProtocol)
+    device.ping()
+
+    firmware_version = device.read_firmware_version()
+    print(f"Firmware version: {firmware_version}")
+
+    dump_iap_firmware(device)
+
+    last_two_pages = device.read_firmware(PAGE_SIZE * (NUM_PAGES - 2), PAGE_SIZE * 2)
+
+    last_flash_page = last_two_pages[:PAGE_SIZE]
+    firmware_length, firmware_crc32 = extract_firmware_info(last_flash_page)
+    print(f"APP firmware length: {hex(firmware_length)}")
+    print(f"APP firmware CRC32: {hex(firmware_crc32)}")
+
+    dump_app_firmware(device, firmware_length)
+
+    option_byte_page = last_two_pages[PAGE_SIZE:]
+    print(f"Option Byte page: {option_byte_page[:0x24]}")
+
+    dump_option_byte(device)

--- a/wrapless.py
+++ b/wrapless.py
@@ -55,6 +55,12 @@ class FingerDetectionOperation(enum.Enum):
     MANUAL = 3
 
 
+@dataclasses.dataclass
+class OptionByte:
+    WriteProtect: bytes
+    MainSecurity: bool
+    FlashSecurity: bool
+
 class Device:
 
     def __init__(self, product: int, proto, timeout: float | None = 5):
@@ -457,6 +463,54 @@ class Device:
             True,
             500,
         )
+
+    def read_firmware(self, addr: int, size: int) -> bytes:
+        assert size < 0x7FFF
+
+        if addr > 0xFFFF:
+            if addr % 0x400 != 0:
+                raise ValueError
+            addr = addr // 0x400
+            size |= 1 << 0xF
+
+        msg = struct.pack("<H", addr)
+        msg += struct.pack("<H", size)
+        self._send_message_to_device(
+            Message(0xF, 1, msg),
+            True,
+            500,
+        )
+
+        reply = self._recv_message_from_device(5000)
+        if reply.category != 0xF or reply.command != 1:
+            raise Exception("Not a firmware read reply")
+
+        return reply.payload
+
+    def read_option_byte(self):
+        msg = b"\x01"
+        self._send_message_to_device(
+            Message(0xF, 4, msg),
+            True,
+            500,
+        )
+
+        reply = self._recv_message_from_device(5000)
+        if reply.category != 0xF or reply.command != 4:
+            raise Exception("Not an option byte read reply")
+
+        if len(reply.payload) != 0x18:
+            raise Exception("Wrong option byte length")
+
+        payload = reply.payload
+
+        write_protect = payload[:0x10]
+        payload = payload[0x10:]
+
+        main_security = int.from_bytes(payload[:0x4], byteorder="little")
+        option_protect = int.from_bytes(payload[0x4:], byteorder="little")
+
+        return OptionByte(write_protect, bool(main_security), bool(option_protect))
 
     def update_firmware(self, firmware: bytes):
         assert len(firmware) < 0x10000

--- a/wrapless.py
+++ b/wrapless.py
@@ -534,6 +534,9 @@ class Device:
             if reply.category != 0xF or reply.command != 0:
                 raise Exception("Not a firmware update reply")
 
+            if reply.payload[0] != 1:
+                raise Exception("Firmware write failed")
+
             sent_bytes += len(firmware_chunk)
             sent_chunks += 1
 


### PR DESCRIPTION
This PR adds a dumper that reads and dumps both the IAP firmware and the APP firmware stored in the sensor flash. In addition, it dumps information about the initialization value and the current value of the option byte (used to manage flash write protection). Finally, it updates the dissector with comments for the FLASH-related messages (all valid messages are documented).