### PR TITLE
fix: flashing 5110 failing

### DIFF
--- a/driver_51x0.py
+++ b/driver_51x0.py
@@ -58,9 +58,7 @@ def check_psk(device: goodix.Device):
         raise ValueError("Invalid flags")
 
     print(f"PSK: {psk.hex()}")
-    # return psk == PMK_HASH
-    return psk != PMK_HASH
-
+    return psk == PMK_HASH
 
 def write_psk(device: goodix.Device):
     if not device.preset_psk_write(0xbb010003, PSK_WHITE_BOX):


### PR DESCRIPTION
This fixes the issue where flashing the psk would always fail. Not sure if this was intentional since the correct code was commented out above?